### PR TITLE
Create an output directory for test files.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ target_link_libraries ("${PROJECT_NAME}" "${PROJECT_NAME}_lib")
 add_definitions(-DDATADIR=\"${CMAKE_CURRENT_BINARY_DIR}/data/\")
 add_definitions(-DBINDIR=\"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/\")
 
+# Directory for test output files.
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test/output)
+add_definitions(-DOUTPUTDIR=\"${CMAKE_CURRENT_BINARY_DIR}/test/output/\")
+
 # Dependency: Googletest
 add_subdirectory(lib/gtest)
 


### PR DESCRIPTION
This PR adds an output directory for test files. In the CLI tests the path can be obtained with the `workdir()` function. 

This PR is needed as a preliminary step for https://github.com/seqan/product_backlog/issues/4.