### PR TITLE
[TEST] automatic fetching of test data; fixes seqan/product_backlog#43

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,16 +17,13 @@ add_subdirectory(src)
 add_executable ("${PROJECT_NAME}" src/main.cpp)
 target_link_libraries ("${PROJECT_NAME}" "${PROJECT_NAME}_lib")
 
-
 ## TEST
-
-# copy test data and define DATADIR
-file(COPY test/data DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/test)
-add_definitions(-DDATADIR=\"${CMAKE_CURRENT_BINARY_DIR}/test/data/\")
+add_definitions(-DDATADIR=\"${CMAKE_CURRENT_BINARY_DIR}/data/\")
 add_definitions(-DBINDIR=\"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/\")
 
 # Dependency: Googletest
 add_subdirectory(lib/gtest)
 
 enable_testing ()
+include(test/data/datasources.cmake)
 add_subdirectory(test)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,6 @@ cmake_minimum_required (VERSION 3.8)
 # Dependency: SeqAn3.
 find_package (SeqAn3 REQUIRED HINTS ../lib/seqan3/build_system)
 
-
 ## BUILD
 
 # An object library (without main) to be used in multiple targets.

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_api_test(fastq_conversion_test.cpp)
+target_use_datasources (fastq_conversion_test FILES in.fastq)

--- a/test/cli/CMakeLists.txt
+++ b/test/cli/CMakeLists.txt
@@ -1,1 +1,2 @@
 add_cli_test(cli_test.cpp)
+target_use_datasources (cli_test FILES in.fastq)

--- a/test/cmake/app_datasources.cmake
+++ b/test/cmake/app_datasources.cmake
@@ -1,0 +1,92 @@
+include (ExternalProject)
+
+# Example call:
+#
+# ```cmake
+# declare_datasource(
+#   FILE pdb100d.ent.gz # build/data/pdb100d.ent.gz
+#   URL ftp://ftp.wwpdb.org/pub/pdb/data/structures/divided/pdb/00/pdb100d.ent.gz # 16KiloByte
+#   URL_HASH SHA256=c2b8f884568b07f58519966e256e2f3aa440508e8013bd10e0ee338e138e62a0)
+# ```
+#
+# Options:
+#
+# declare_datasource(FILE <datasource name> URL <url1> [<url2>...] [URL_HASH <algo>=<hashValue>] [<option>...])
+#
+# FILE <datasource name> (required):
+#    The name of the downloaded file (must be unique across all declared datasources).
+#    This will put the file into the ``<build>/data/<datasource name>`` folder.
+#
+# URL <url1> [<url2>...] (required):
+#    List of paths and/or URL(s) of the external datasource. When more than one URL is given, they are tried in
+#    turn until one succeeds. A URL may be an ordinary path in the local file system (in which case it must be the only
+#    URL provided) or any downloadable URL supported by the file(DOWNLOAD) command. A local filesystem path may refer to
+#    either an existing directory or to an archive file, whereas a URL is expected to point to a file which can be
+#    treated as an archive.
+#
+# URL_HASH <algo>=<hashValue> (optional):
+#    Hash of the archive file to be downloaded. The argument should be of the form <algo>=<hashValue> where algo can be
+#    any of the hashing algorithms supported by the file() command. Specifying this option is strongly recommended for
+#    URL downloads, as it ensures the integrity of the downloaded content. It is also used as a check for a previously
+#    downloaded file, allowing connection to the remote location to be avoided altogether if the local directory already
+#    has a file from an earlier download that matches the specified hash.
+#
+# This uses under the hood ExternalProject's and you can pass any viable option of ExternalProject to this function and
+# overwrite the default behaviour. See https://cmake.org/cmake/help/latest/module/ExternalProject.html for more
+# information.
+function(declare_datasource)
+    set(options "")
+    set(one_value_args FILE URL_HASH)
+    set(multi_value_args URL)
+
+    cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
+
+    string(TOLOWER "datasource--${ARG_FILE}" datasource_name)
+
+    # create data folder
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/data)
+
+    ExternalProject_Add(
+        "${datasource_name}"
+        URL "${ARG_URL}"
+        URL_HASH "${ARG_URL_HASH}"
+        DOWNLOAD_NAME "${ARG_FILE}"
+        CONFIGURE_COMMAND ""
+        BUILD_COMMAND ""
+        INSTALL_COMMAND
+            ${CMAKE_COMMAND} -E create_symlink <DOWNLOADED_FILE> ${CMAKE_CURRENT_BINARY_DIR}/data/${ARG_FILE}
+        TEST_COMMAND ""
+        PREFIX "${CMAKE_CURRENT_BINARY_DIR}/_datasources"
+        DOWNLOAD_NO_EXTRACT TRUE # don't extract archive files like .tar.gz.
+        ${ARG_UNPARSED_ARGUMENTS}
+    )
+endfunction()
+
+# Example call:
+#
+# ```cmake
+# # my_app uses and needs the files RF00001.fa.gz, pdb100d.ent.gz, and GRCh38_latest_clinvar.vcf.gz.
+# target_use_datasources(my_app FILES RF00001.fa.gz pdb100d.ent.gz GRCh38_latest_clinvar.vcf.gz)
+# ```
+#
+# Options:
+#
+# target_use_datasources(<target> FILES <file1> [<file2>...])
+#
+# It declares that a <target> uses and depends on the following files.
+#
+# This also sets the build requirement that the files must be downloaded before the <target> will be build.
+#
+# The named <target> must have been created by a command such as add_executable() or add_library().
+function(target_use_datasources target)
+    set(options "")
+    set(one_value_args)
+    set(multi_value_args "FILES")
+
+    cmake_parse_arguments(ARG "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN})
+
+    foreach(filename ${ARG_FILES})
+        string(TOLOWER "datasource--${filename}" datasource_name)
+        add_dependencies ("${target}" "${datasource_name}")
+    endforeach()
+endfunction()

--- a/test/data/datasources.cmake
+++ b/test/data/datasources.cmake
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.8)
+
+include (test/cmake/app_datasources.cmake)
+
+# copies file to <build>/data/in.fastq
+declare_datasource(FILE in.fastq
+                   URL ${CMAKE_SOURCE_DIR}/test/data/in.fastq
+                   URL_HASH SHA256=6e30fc35f908a36fe0c68a7a35c47f51f9570da16622fb0c072a20e6a9ba5b3e)


### PR DESCRIPTION
This PR fixes seqan/product_backlog#43

### Acceptance Criteria

<!-- All the stuff that needs to be done, besides the Definition of Done for this story. -->

- [x] specifying a remote resource with a file to download the file will be downloaded during the build of the test.
- [x] if the test data is already present nothing will be downloaded.
- [x] if the data is not reachable from the remote location a build error occurs with a diagnostic message



<details>
  <summary>This happens if unreachable:</summary>

```
-- verifying file...
       file='/home/marehr/develope/app-template/build/data//foo.gz'
-- SHA256 hash of
    /home/marehr/develope/app-template/build/data//foo.gz
  does not match expected value
    expected: '6e30fc35f908a36fe0c68a7a35c47f51f9570da16622fb0c072a20e6a9ba5b3e'
      actual: 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
-- File already exists but hash mismatch. Removing...
-- Downloading...
   dst='/home/marehr/develope/app-template/build/data//foo.gz'
   timeout='none'
-- Using src='https://example.unreachable/foo.gz'
-- Retrying...
-- Using src='https://example.unreachable/foo.gz'
-- Retry after 5 seconds (attempt #2) ...
-- Using src='https://example.unreachable/foo.gz'
-- Retry after 5 seconds (attempt #3) ...
-- Using src='https://example.unreachable/foo.gz'
-- Retry after 15 seconds (attempt #4) ...
-- Using src='https://example.unreachable/foo.gz'
-- Retry after 60 seconds (attempt #5) ...
-- Using src='https://example.unreachable/foo.gz'
CMake Error at _datasources/src/datasource_in.fastq-stamp/download-datasource_in.fastq.cmake:159 (message):
  Each download failed!

    error: downloading 'https://example.unreachable/foo.gz' failed
         status_code: 6
         status_string: "Couldn't resolve host name"
         log:
         --- LOG BEGIN ---
         Could not resolve host: example.unreachable

  Closing connection 0

  

         --- LOG END ---
         error: downloading 'https://example.unreachable/foo.gz' failed
         status_code: 6
         status_string: "Couldn't resolve host name"
         log:
         --- LOG BEGIN ---
         Could not resolve host: example.unreachable

  Closing connection 0

  

         --- LOG END ---
         error: downloading 'https://example.unreachable/foo.gz' failed
         status_code: 6
         status_string: "Couldn't resolve host name"
         log:
         --- LOG BEGIN ---
         Could not resolve host: example.unreachable

  Closing connection 0

  

         --- LOG END ---
         error: downloading 'https://example.unreachable/foo.gz' failed
         status_code: 6
         status_string: "Couldn't resolve host name"
         log:
         --- LOG BEGIN ---
         Could not resolve host: example.unreachable

  Closing connection 0

  

         --- LOG END ---
         error: downloading 'https://example.unreachable/foo.gz' failed
         status_code: 6
         status_string: "Couldn't resolve host name"
         log:
         --- LOG BEGIN ---
         Could not resolve host: example.unreachable

  Closing connection 0

  

         --- LOG END ---
         error: downloading 'https://example.unreachable/foo.gz' failed
         status_code: 6
         status_string: "Couldn't resolve host name"
         log:
         --- LOG BEGIN ---
         Could not resolve host: example.unreachable

  Closing connection 0

  

         --- LOG END ---
```
</details>

### Tasks

<!-- The tasks which need to be tackled for this story to be completed. They are likely to be defined later when the team plans this story for the next iteration and discusses the design. --> 

- [x] add cmake function to download a remote file.

### What works right now:
* Specify any number of alternative URLs for a single file:
  ```cmake
  declare_datasource(FILE human_chr1.fastq
                     URL https://example.com/human_chr1.fastq
                         https://example2.com/human_chr1.fastq
                         https://example3.com/human_chr1.fastq)
  ```
  if one host fails cmake will try the next one.
* Rename a file
  ```cmake
  declare_datasource(FILE chr1.fastq URL https://example.com/human_chr1.fastq)
  ```
  `human_chr1.fastq` will be renamed to `chr1.fastq`

### What doesn't works right now:
* [ ] Deleting downloaded file with `make clean` and make them reappear after executing `make` again.
* [ ] Nested folder structures in `data`; I can't declare 
  ```cmake
  declare_datasource(FILE human/chr1.fastq URL https://example.com/human_chr1.fastq)
  declare_datasource(FILE ape/chr1.fastq URL https://example.com/ape_chr1.fastq)
  ```