### PR TITLE
Add doc build to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,30 @@ jobs:
         - CXX=g++-9
         - CC=gcc-9
         - BUILD_TYPE=Release
+    - os: linux
+      name: "Documentation"
+      addons:
+        apt:
+          sources:
+            - sourceline: 'ppa:ubuntu-toolchain-r/test'
+          packages:
+            - g++-9
+            - doxygen
+            - doxygen-doc
+            - doxygen-latex
+            - graphviz
+      script:
+        - doxygen --version
+        - doxygen -u doc/Doxyfile
+        - make -j 2 doc 2>doxygen_warnings.txt
+        - cat doxygen_warnings.txt && test ! -s doxygen_warnings.txt
+      env:
+        - CXX=g++-9
+        - CC=gcc-9
+        - BUILD_TYPE=Debug
+  allow_failures:
+    - name: "Documentation"
+  fast_finish: true
 
 install:
   - |


### PR DESCRIPTION
This PR adds a Travis target that builds the documentation with doxygen. It is intended to inform the app developer about the documentation build status. Its success or failure does not impact the overall build status. I made this decision, because some apps may not want to care about doxygen warnings.

This PR is dependent on #10, because it uses the `make doc` target. This PR can only show green light for 'Documentation' after #10 is merged.