### PR TITLE
Change the "make all" target to build application only.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -107,6 +107,6 @@ before_script:
   - cmake .. -DCMAKE_BUILD_TYPE=${BUILD_TYPE}
 
 script:
-  - make -k -j2
+  - make -k -j2 api_test cli_test
   - ctest . --output-on-failure
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,26 +5,33 @@ cmake_minimum_required (VERSION 3.8)
 # Define the application name and version.
 project (fastq_to_fasta VERSION 1.0.0)
 set (CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
 
 ## BUILD
 
 # Specify the directories where to store the built archives, libraries and executables
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set (CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
+
+# Messages
+string (ASCII 27 Esc)
+set (FontBold "${Esc}[1m")
+set (FontReset "${Esc}[m")
 
 # Dependency: SeqAn3.
-find_package (SeqAn3 REQUIRED HINTS lib/seqan3/build_system)
+find_package (SeqAn3 QUIET REQUIRED HINTS lib/seqan3/build_system)
 
-add_subdirectory(src)
-
-## TEST
-
-add_subdirectory(lib/gtest EXCLUDE_FROM_ALL)
-enable_testing ()
-add_subdirectory(test EXCLUDE_FROM_ALL)
+add_subdirectory (src)
+message (STATUS "${FontBold}You can run `make` to build the application.${FontReset}")
 
 ## DOCUMENTATION
 
-add_subdirectory(doc EXCLUDE_FROM_ALL)
+add_subdirectory (doc EXCLUDE_FROM_ALL)
+
+## TEST
+
+add_subdirectory (lib/gtest EXCLUDE_FROM_ALL)
+enable_testing ()
+add_subdirectory (test EXCLUDE_FROM_ALL)
+message (STATUS "${FontBold}You can run `make test` to build and run tests.${FontReset}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,31 +7,24 @@ project (fastq_to_fasta VERSION 1.0.0)
 set (CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+## BUILD
+
 # Specify the directories where to store the built archives, libraries and executables
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
-## BUILD
+# Dependency: SeqAn3.
+find_package (SeqAn3 REQUIRED HINTS lib/seqan3/build_system)
+
 add_subdirectory(src)
-add_executable ("${PROJECT_NAME}" src/main.cpp)
-target_link_libraries ("${PROJECT_NAME}" "${PROJECT_NAME}_lib")
 
 ## TEST
-add_definitions(-DDATADIR=\"${CMAKE_CURRENT_BINARY_DIR}/data/\")
-add_definitions(-DBINDIR=\"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/\")
 
-# Directory for test output files.
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/test/output)
-add_definitions(-DOUTPUTDIR=\"${CMAKE_CURRENT_BINARY_DIR}/test/output/\")
-
-# Dependency: Googletest
-add_subdirectory(lib/gtest)
-
+add_subdirectory(lib/gtest EXCLUDE_FROM_ALL)
 enable_testing ()
-include(test/data/datasources.cmake)
-add_subdirectory(test)
-
+add_subdirectory(test EXCLUDE_FROM_ALL)
 
 ## DOCUMENTATION
-add_subdirectory(doc)
+
+add_subdirectory(doc EXCLUDE_FROM_ALL)

--- a/README.md
+++ b/README.md
@@ -2,23 +2,15 @@
 
 [![Build Status](https://travis-ci.com/joergi-w/app-template.svg?branch=master)](https://travis-ci.com/joergi-w/app-template)
 
-This is a template for app developers with SeqAn3. You can easily clone this repository and modify the existing code to your needs. It provides the elementary set-up for all SeqAn3 applications.
+This is a template for app developers with SeqAn3. 
+You can easily clone this repository and modify the existing code to your needs. 
+It provides the elementary set-up for all SeqAn3 applications.
 
 Instructions:
 1. clone this repository: `git clone --recurse-submodules https://github.com/joergi-w/app-template.git`
 2. create a build directory and visit it: `mkdir build && cd build`
 3. run cmake: `cmake ../app-template`
-4. run `make`
-5. run the tests: `make test`
+4. build the application: `make`
+5. optional: build and run the tests: `make test`
 6. optional: build the api documentation: `make doc`
 7. execute the app: `./my_app`
-
-Planned features are:
-- build the app with seqan3
-- cli tests (black box)
-- api tests (white box)
-- tutorials, usage instructions
-- benchmarks for time, memory and disk space consumption
-- coverage tests: api
-- automated CD
-- automated CI

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,29 +1,26 @@
-# Minimum cmake version
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required (VERSION 3.8)
 
-### Find doxygen and dependency to DOT tool
-message (STATUS "Searching for doxygen.")
+# Find doxygen.
 find_package (Doxygen QUIET)
 
 if (${DOXYGEN_FOUND})
+    message (STATUS "Found Doxygen: ${DOXYGEN_EXECUTABLE}")
 
-    ### Configure doc/developer targets.
-    set(APP_TEMPLATE_DOXYFILE_IN ${CMAKE_SOURCE_DIR}/doc/doxygen_cfg)
+    # Configure doxygen options.
+    set (APP_TEMPLATE_DOXYFILE_IN ${CMAKE_SOURCE_DIR}/doc/doxygen_cfg)
+    set (APP_TEMPLATE_DOXYGEN_OUTPUT_DIR "${PROJECT_BINARY_DIR}/doc")
+    set (APP_TEMPLATE_DOXYGEN_EXCLUDE_SYMBOLS "")
+    set (APP_TEMPLATE_DOXYGEN_PREDEFINED_NDEBUG "")
+    set (APP_TEMPLATE_DOXYGEN_ENABLED_SECTIONS "DEV")
+    set (APP_TEMPLATE_DOXYGEN_EXTRACT_PRIVATE "YES")
 
-    message(STATUS "Configuring doc.")
-
-    set(APP_TEMPLATE_DOXYGEN_OUTPUT_DIR "${PROJECT_BINARY_DIR}/doc")
-    set(APP_TEMPLATE_DOXYGEN_EXCLUDE_SYMBOLS "")
-    set(APP_TEMPLATE_DOXYGEN_PREDEFINED_NDEBUG "")
-    set(APP_TEMPLATE_DOXYGEN_ENABLED_SECTIONS "DEV")
-    set(APP_TEMPLATE_DOXYGEN_EXTRACT_PRIVATE "YES")
-
-    configure_file(${APP_TEMPLATE_DOXYFILE_IN} ${APP_TEMPLATE_DOXYGEN_OUTPUT_DIR}/Doxyfile)
-
-    add_custom_target(doc
-                        COMMAND ${DOXYGEN_EXECUTABLE}
-                        WORKING_DIRECTORY ${APP_TEMPLATE_DOXYGEN_OUTPUT_DIR}
-                        COMMENT "Generating (developer) API documentation with Doxygen."
-                        VERBATIM)
-
+    configure_file (${APP_TEMPLATE_DOXYFILE_IN} ${APP_TEMPLATE_DOXYGEN_OUTPUT_DIR}/Doxyfile)
+    add_custom_target (doc
+                       COMMAND ${DOXYGEN_EXECUTABLE}
+                       WORKING_DIRECTORY ${APP_TEMPLATE_DOXYGEN_OUTPUT_DIR}
+                       COMMENT "Generating (developer) API documentation with Doxygen."
+                       VERBATIM)
+    message (STATUS "${FontBold}You can run `make doc` to build api documentation.${FontReset}")
+else ()
+    message (STATUS "Doxygen not found.")
 endif ()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,13 +1,9 @@
 cmake_minimum_required (VERSION 3.8)
 
-## DEPENDENCIES
-
-# Dependency: SeqAn3.
-find_package (SeqAn3 REQUIRED HINTS ../lib/seqan3/build_system)
-
-## BUILD
-
 # An object library (without main) to be used in multiple targets.
 add_library ("${PROJECT_NAME}_lib" STATIC fastq_conversion.cpp)
 target_link_libraries ("${PROJECT_NAME}_lib" PUBLIC seqan3::seqan3)
 target_include_directories ("${PROJECT_NAME}_lib" PUBLIC ../include)
+
+add_executable ("${PROJECT_NAME}" main.cpp)
+target_link_libraries ("${PROJECT_NAME}" "${PROJECT_NAME}_lib")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,23 @@
 cmake_minimum_required (VERSION 3.8)
 
+# Set directories for test output files, input data and binaries.
+file (MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/output)
+add_definitions (-DOUTPUTDIR=\"${CMAKE_CURRENT_BINARY_DIR}/output/\")
+add_definitions (-DDATADIR=\"${CMAKE_CURRENT_BINARY_DIR}/data/\")
+add_definitions (-DBINDIR=\"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/\")
+
+# Build tests before execution because they are not built with "all" target.
+file (WRITE "${CMAKE_CURRENT_BINARY_DIR}/build_test_targets.cmake"
+            "execute_process(COMMAND ${CMAKE_COMMAND} --build . --target api_test)\n"
+            "execute_process(COMMAND ${CMAKE_COMMAND} --build . --target cli_test)")
+set_directory_properties (PROPERTIES TEST_INCLUDE_FILE "${CMAKE_CURRENT_BINARY_DIR}/build_test_targets.cmake")
+
+include (data/datasources.cmake)
+
+# Define the test targets.
+add_custom_target (api_test)
+add_custom_target (cli_test)
+
 unset(CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
 unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 unset(CMAKE_RUNTIME_OUTPUT_DIRECTORY)
@@ -18,6 +36,9 @@ macro (add_app_test test_filename test_alternative)
     # Add main application as a dependency for command line tests
     if (${test_alternative} STREQUAL "CLI_TEST")
         add_dependencies(${target} "${PROJECT_NAME}")
+        add_dependencies(cli_test ${target})
+    elseif (${test_alternative} STREQUAL "API_TEST")
+        add_dependencies(api_test ${target})
     endif()
 
     get_filename_component (target_relative_path "${source_file}" DIRECTORY)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -12,43 +12,39 @@ file (WRITE "${CMAKE_CURRENT_BINARY_DIR}/build_test_targets.cmake"
             "execute_process(COMMAND ${CMAKE_COMMAND} --build . --target cli_test)")
 set_directory_properties (PROPERTIES TEST_INCLUDE_FILE "${CMAKE_CURRENT_BINARY_DIR}/build_test_targets.cmake")
 
-include (data/datasources.cmake)
-
 # Define the test targets.
 add_custom_target (api_test)
 add_custom_target (cli_test)
 
-unset(CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
-unset(CMAKE_LIBRARY_OUTPUT_DIRECTORY)
-unset(CMAKE_RUNTIME_OUTPUT_DIRECTORY)
+unset (CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
+unset (CMAKE_LIBRARY_OUTPUT_DIRECTORY)
+unset (CMAKE_RUNTIME_OUTPUT_DIRECTORY)
 
-# A macro that adds an api or cli test
+# A macro that adds an api or cli test.
 macro (add_app_test test_filename test_alternative)
-
+    # Extract the test target name.
     file (RELATIVE_PATH source_file "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_LIST_DIR}/${test_filename}")
-
     get_filename_component (target "${source_file}" NAME_WE)
 
+    # Create the test target.
     add_executable (${target} ${test_filename})
-
     target_link_libraries (${target} "${PROJECT_NAME}_lib" seqan3::seqan3 gmock gmock_main gtest pthread)
 
-    # Add main application as a dependency for command line tests
+    # Add the test to its general target (cli or api).
     if (${test_alternative} STREQUAL "CLI_TEST")
-        add_dependencies(${target} "${PROJECT_NAME}")
-        add_dependencies(cli_test ${target})
+        add_dependencies (${target} "${PROJECT_NAME}") # cli test needs the application executable
+        add_dependencies (cli_test ${target})
     elseif (${test_alternative} STREQUAL "API_TEST")
-        add_dependencies(api_test ${target})
-    endif()
+        add_dependencies (api_test ${target})
+    endif ()
 
+    # Generate and set the test name.
     get_filename_component (target_relative_path "${source_file}" DIRECTORY)
-
     if (target_relative_path)
         set (test_name "${target_relative_path}/${target}")
     else ()
         set (test_name "${target}")
     endif ()
-
     add_test (NAME "${test_name}" COMMAND ${target})
 
     unset (source_file)
@@ -56,16 +52,17 @@ macro (add_app_test test_filename test_alternative)
     unset (test_name)
 endmacro ()
 
-# A macro that adds an api test
+# A macro that adds an api test.
 macro (add_api_test test_filename)
-    add_app_test(${test_filename} API_TEST)
-endmacro()
+    add_app_test (${test_filename} API_TEST)
+endmacro ()
 
-# A macro that adds an cli test
+# A macro that adds a cli test.
 macro (add_cli_test test_filename)
-    add_app_test(${test_filename} CLI_TEST)
-endmacro()
+    add_app_test (${test_filename} CLI_TEST)
+endmacro ()
 
-# Add subdirectories
+# Fetch data and add the tests.
+include (data/datasources.cmake)
 add_subdirectory (api)
 add_subdirectory (cli)

--- a/test/api/CMakeLists.txt
+++ b/test/api/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_api_test(convert_fastq_test.cpp)
+cmake_minimum_required (VERSION 3.8)
+
+add_api_test (convert_fastq_test.cpp)
 target_use_datasources (convert_fastq_test FILES in.fastq)

--- a/test/api/README.md
+++ b/test/api/README.md
@@ -1,4 +1,6 @@
 # API Test
 
-Here are test files for whitebox tests, i.e. the internal functions of the app are executed with different input parameters. The test then validates whether the functions work correctly.
-
+Here are test files for API tests, i.e. the internal functions of the app are executed with different input parameters.
+The test then validates whether the functions work correctly.
+Attention: The default `make` target does not build tests.
+Please invoke the build with `make api_test` or use `make test` to build and run all kinds of tests.

--- a/test/benchmark/README.md
+++ b/test/benchmark/README.md
@@ -1,4 +1,6 @@
 # Benchmarks
 
-Here are test files for benchmarks with respect to time, space consumption and memory. They are usually based on the command-line interface, but you can also add micro benchmark if you wish.
+Here are test files for benchmarks with respect to time, space consumption and memory.
+They are usually based on the command-line interface, but you can also add micro benchmark if you wish.
 
+The benchmark tests are not yet implemented.

--- a/test/cli/CMakeLists.txt
+++ b/test/cli/CMakeLists.txt
@@ -1,2 +1,4 @@
-add_cli_test(fastq_to_fasta_options_test.cpp)
+cmake_minimum_required (VERSION 3.8)
+
+add_cli_test (fastq_to_fasta_options_test.cpp)
 target_use_datasources (fastq_to_fasta_options_test FILES in.fastq)

--- a/test/cli/README.md
+++ b/test/cli/README.md
@@ -5,3 +5,7 @@ The test then validates whether the output is correct.
 
 Each test fixture should be inherited from the `cli_test` class: It provides the functionality of executing the app,
 finding the input files, capturing the output and creating individual test directories.
+The test output files are stored in the directory `test/output`
+
+Attention: The default `make` target does not build tests.
+Please invoke the build with `make cli_test` or use `make test` to build and run all kinds of tests.

--- a/test/coverage/README.md
+++ b/test/coverage/README.md
@@ -1,4 +1,6 @@
 # Coverage Test
 
-This is the test for the code coverage. It reaches 100% if each code line is executed at least once through the app tests.
+This is the test for the code coverage.
+It reaches 100% if each code line is executed at least once through the app tests.
 
+The coverage tests are not yet implemented.

--- a/test/data/README.md
+++ b/test/data/README.md
@@ -1,4 +1,5 @@
 # Data Directory
 
-Store the data here that should be used as input files for the tests. Large files (>50kb) should not be stored here, but rather fetched from a webserver.
-
+Store the data here that should be used as input files for the tests.
+Large files (>50kb) should not be stored here, but rather fetched from a webserver.
+Register each file (from external or internal storage) in the `datasources.cmake` file.

--- a/test/data/datasources.cmake
+++ b/test/data/datasources.cmake
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.8)
 
-include (test/cmake/app_datasources.cmake)
+include (cmake/app_datasources.cmake)
 
 # copies file to <build>/data/in.fastq
 declare_datasource(FILE in.fastq

--- a/test/data/datasources.cmake
+++ b/test/data/datasources.cmake
@@ -1,8 +1,8 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required (VERSION 3.8)
 
 include (cmake/app_datasources.cmake)
 
 # copies file to <build>/data/in.fastq
-declare_datasource(FILE in.fastq
-                   URL ${CMAKE_SOURCE_DIR}/test/data/in.fastq
-                   URL_HASH SHA256=6e30fc35f908a36fe0c68a7a35c47f51f9570da16622fb0c072a20e6a9ba5b3e)
+declare_datasource (FILE in.fastq
+                    URL ${CMAKE_SOURCE_DIR}/test/data/in.fastq
+                    URL_HASH SHA256=6e30fc35f908a36fe0c68a7a35c47f51f9570da16622fb0c072a20e6a9ba5b3e)


### PR DESCRIPTION
This PR changes the behaviour of the `make all` target (and implicitly of the default `make` call): It builds only the application, but no documentation or tests.

I added explanatory messages to the cmake build saying how to obtain the test or doc builds. 

Furthermore, I added a property to the test directory, which builds the tests always before execution – otherwise `make test` (a non-modifiable target created automatically by cmake) would have failed because the tests are not built. 

This PR closes https://github.com/seqan/product_backlog/issues/41.