### PR TITLE
Download Googletest on demand during 'make test' routine.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,6 +2,3 @@
 	path = lib/seqan3
 	url = https://github.com/seqan/seqan3.git
 	branch = master
-[submodule "gtest"]
-	path = lib/gtest
-	url = https://github.com/google/googletest.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,5 @@ add_subdirectory (doc EXCLUDE_FROM_ALL)
 
 ## TEST
 
-add_subdirectory (lib/gtest EXCLUDE_FROM_ALL)
 enable_testing ()
 add_subdirectory (test EXCLUDE_FROM_ALL)
-message (STATUS "${FontBold}You can run `make test` to build and run tests.${FontReset}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,16 +6,22 @@ add_definitions (-DOUTPUTDIR=\"${CMAKE_CURRENT_BINARY_DIR}/output/\")
 add_definitions (-DDATADIR=\"${CMAKE_CURRENT_BINARY_DIR}/data/\")
 add_definitions (-DBINDIR=\"${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/\")
 
-# Build tests before execution because they are not built with "all" target.
+# Download and build Googletest module. The interface target 'gtest_all' contains all libs and header paths.
+message (STATUS "Configuring tests. Googletest will be downloaded on demand only.")
+include (cmake/build_googletest.cmake)
+
+# Build tests just before their execution, because they have not been built with "all" target.
+# The trick is here to provide a cmake file as a directory property that executes the build command.
 file (WRITE "${CMAKE_CURRENT_BINARY_DIR}/build_test_targets.cmake"
             "execute_process(COMMAND ${CMAKE_COMMAND} --build . --target api_test)\n"
             "execute_process(COMMAND ${CMAKE_COMMAND} --build . --target cli_test)")
 set_directory_properties (PROPERTIES TEST_INCLUDE_FILE "${CMAKE_CURRENT_BINARY_DIR}/build_test_targets.cmake")
 
-# Define the test targets.
+# Define the test targets. All depending targets are built just before the test execution.
 add_custom_target (api_test)
 add_custom_target (cli_test)
 
+# Test executables and libraries should not mix with the application files.
 unset (CMAKE_ARCHIVE_OUTPUT_DIRECTORY)
 unset (CMAKE_LIBRARY_OUTPUT_DIRECTORY)
 unset (CMAKE_RUNTIME_OUTPUT_DIRECTORY)
@@ -28,7 +34,7 @@ macro (add_app_test test_filename test_alternative)
 
     # Create the test target.
     add_executable (${target} ${test_filename})
-    target_link_libraries (${target} "${PROJECT_NAME}_lib" seqan3::seqan3 gmock gmock_main gtest pthread)
+    target_link_libraries (${target} "${PROJECT_NAME}_lib" seqan3::seqan3 gtest_all pthread)
 
     # Add the test to its general target (cli or api).
     if (${test_alternative} STREQUAL "CLI_TEST")
@@ -66,3 +72,5 @@ endmacro ()
 include (data/datasources.cmake)
 add_subdirectory (api)
 add_subdirectory (cli)
+
+message (STATUS "${FontBold}You can run `make test` to build and run tests.${FontReset}")

--- a/test/cmake/build_googletest.cmake
+++ b/test/cmake/build_googletest.cmake
@@ -1,0 +1,30 @@
+cmake_minimum_required (VERSION 3.8)
+
+# Register how to download Googletest.
+include (ExternalProject)
+ExternalProject_Add (googletest
+                     GIT_REPOSITORY    "https://github.com/google/googletest.git"
+                     GIT_TAG           "master"
+                     GIT_SHALLOW
+                     PREFIX            "${CMAKE_CURRENT_BINARY_DIR}/googletest"
+                     UPDATE_COMMAND    ""   # omit update step
+                     INSTALL_COMMAND   "")  # do not install
+
+# The 4 library targets of googletest are combined in the gtest_all interface.
+add_library (gtest_all INTERFACE)
+ExternalProject_Get_Property (googletest binary_dir)
+foreach (target "gtest" "gmock" "gtest_main" "gmock_main")
+    # Import the library from the googletest build directory.
+    add_library (${target} UNKNOWN IMPORTED)
+    set_target_properties (${target} PROPERTIES
+                           IMPORTED_LOCATION "${binary_dir}/lib/${CMAKE_FIND_LIBRARY_PREFIXES}${target}.a")
+    # Require googletest to be downloaded before the library is created.
+    add_dependencies (${target} googletest)
+    # Add the library to the 'gtest_all' interface target.
+    target_link_libraries (gtest_all INTERFACE ${target})
+endforeach ()
+
+# Add the include directories to the 'gtest_all' interface target.
+ExternalProject_Get_Property (googletest source_dir)
+target_include_directories (gtest_all INTERFACE "${source_dir}/googletest/include")
+target_include_directories (gtest_all INTERFACE "${source_dir}/googlemock/include")


### PR DESCRIPTION
In this PR I remove the submodule for Googletest and instead treat it as external project that is downloaded just before the first access. 

For the user, the 'make test' command has the following workflow:
1. Download Googletest
2. Build Googletest
3. Download external test input files [in parallel with 1-2]
4. Build test targets and link to Googletest
5. Run tests

Note: I did not use FETCH_CONTENT as suggested in the issue, because it would download already in the cmake configuration process. Instead, we want to download during build time.

This PR closes https://github.com/seqan/product_backlog/issues/47.